### PR TITLE
Add license, pip style package install, basic unit testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,167 @@
-.idea
-**/__pycache__/
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+.idea/
+
+# Repository specific files to ignore.
+*.gz
+*.pyc
+freyja/variantfiles/
+freyja/depthfiles/
+freyja/cladePaths.txt

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+# MIT License
+
+Copyright (c) 2021 outbreakinfo authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,34 @@
+# adapted from qqiime2, freyja
+.PHONY: all lint test test-cov install dev clean distclean
+
+PYTHON ?= python
+
+all: ;
+
+lint:
+	flake8 Python-outbreak-info
+
+test: all
+	py.test
+
+test-install: all
+	# ensure the package is installed and the app is buildable. this test
+	# is a passive verification that non-py essential files are part of the
+	# installed entity.
+	cd /  # go somewhere to avoid relative imports
+	python -c "import outbreak_data"
+	python -c "import outbreak_tools"
+
+# test-cov: all
+# 	py.test --cov=outbreakpy
+# 	coveralls
+
+install: all
+	$(PYTHON) setup.py install
+
+dev: all
+	pip install -e .
+
+clean: distclean
+
+distclean: ;

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,30 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2021-, Outbreak.info development team.
+#
+# Distributed under the terms of the MIT License
+#
+# The full license is in the file LICENSE.md, distributed with this software.
+# ----------------------------------------------------------------------------
+from setuptools import setup, find_packages
+
+with open('README.md') as f:
+    long_description = f.read()
+
+
+description = ("Python interface to Outbreak.info,"
+               " powered by GISAID")
+
+
+setup(
+    name="python-outbreak-info",
+    version="1.0",
+    packages=find_packages(),
+    author="Outbreak.info dev team",
+    license='MIT',
+    author_email="lhughes@scripps.edu",
+    url="https://github.com/outbreak-info/python-outbreak-info",
+    description=description,
+    long_description=long_description,
+    long_description_content_type='text/markdown',
+    install_requires=["numpy", "pandas","requests"]
+)

--- a/tests/test_outbreak_data.py
+++ b/tests/test_outbreak_data.py
@@ -4,6 +4,8 @@ import pytest
 import requests
 import os
 from outbreak_data import outbreak_data
+from outbreak_data import authenticate_user
+
 test_server = 'test.outbreak.info'
 null_server = 'null.outbreak.info'
 


### PR DESCRIPTION
Users should now be able to install the package with ```pip install -e .``` when in the repo. Although not all of the tests are passing at the moment, we can now run them all with a standard ```make test```. 
@srandall02 and @cmaceves we'll need to make sure we can pass all of the tests ;)